### PR TITLE
Add advanced wildcard support for 8.1+ Controllers

### DIFF
--- a/exporter/export_legacy_policy_bundle.py
+++ b/exporter/export_legacy_policy_bundle.py
@@ -479,6 +479,26 @@ def get_gateway_details(controller_ip, cid):
     return response.json()
 
 
+def get_controller_version(controller_ip, cid):
+    """
+    Retrieve controller version information from the Aviatrix controller.
+    
+    This function fetches the controller version information which can be used
+    for version-specific logic in the translation process.
+    
+    Args:
+        controller_ip (str): IP address or hostname of the Aviatrix controller
+        cid (str): Session token from login
+        
+    Returns:
+        dict: JSON response containing controller version information
+    """
+    print("Getting controller version information.")
+    response = aviatrix_api_call(controller_ip=controller_ip, path="/v2/api",
+                                 cid=cid, params={'action': 'list_version_info'})
+    return response.json()
+
+
 def get_vpc_routes(controller_ip, cid, gateway_details):
     """
     Collect VPC route table information for all gateways.
@@ -774,6 +794,9 @@ def main():
     # Get gateway details using the CID - this provides VPC and gateway information
     gateway_details = get_gateway_details(args.controller_ip, cid)
 
+    # Get controller version information
+    controller_version = get_controller_version(args.controller_ip, cid)
+
     # Optionally get VPC route tables if requested
     # This is useful for migration scenarios involving transit gateways
     if args.vpc_routes:
@@ -785,6 +808,10 @@ def main():
     # Write the gateway details to the output file as JSON
     with open('gateway_details.json', 'w') as f:
         json.dump(gateway_details, f, indent=1)
+
+    # Write the controller version to the output file as JSON
+    with open('controller_version.json', 'w') as f:
+        json.dump(controller_version, f, indent=1)
 
     # Optionally get the ID of the "Any-Web" webgroup (requires controller v7.1+)
     # This is required for the translator script
@@ -805,7 +832,7 @@ def main():
 
     # Bundle all the files into a ZIP and delete the original files to clean up
     # Determine which additional files to include based on command line options
-    other_files = ["gateway_details.json"]
+    other_files = ["gateway_details.json", "controller_version.json"]
     if args.any_web:
         other_files.append("any_webgroup.json")
     if args.vpc_routes:

--- a/translator/src/config/defaults.py
+++ b/translator/src/config/defaults.py
@@ -21,6 +21,7 @@ TERRAFORM_FILE_PATTERNS = {
     "smart_group": "smart_group.tf",
     "gateway_details": "gateway_details.json",
     "copilot_app_domains": "copilot_app_domains.json",
+    "controller_version": "controller_version.json",
 }
 
 # Output file names

--- a/translator/src/config/defaults.py
+++ b/translator/src/config/defaults.py
@@ -18,7 +18,6 @@ TERRAFORM_FILE_PATTERNS = {
     "firewall_tag": "firewall_tag.tf",
     "fqdn": "fqdn.tf",
     "fqdn_tag_rule": "fqdn_tag_rule.tf",
-    "smart_group": "smart_group.tf",
     "gateway_details": "gateway_details.json",
     "copilot_app_domains": "copilot_app_domains.json",
     "controller_version": "controller_version.json",

--- a/translator/src/config/settings.py
+++ b/translator/src/config/settings.py
@@ -58,6 +58,9 @@ class TranslationConfig:
     enable_custom_internet_smartgroup: bool = True
     custom_internet_smartgroup_name: str = "Internet_Custom"
 
+    # Advanced domain handling
+    include_advanced_wildcards: bool = False
+
     # Optional customer/organization context
     customer_name: Optional[str] = None
     organization_name: Optional[str] = None

--- a/translator/src/data/exporters.py
+++ b/translator/src/data/exporters.py
@@ -203,6 +203,7 @@ class CSVExporter:
             "smartgroups_df": "smartgroups.csv",
             "removed_duplicates": "removed_duplicate_policies.csv",
             "unsupported_fqdn_domains_df": "unsupported_fqdn_domains.csv",
+            "unsupported_cidr_entries_df": "unsupported_cidr_entries.csv",
         }
 
         for key, filename in output_exports.items():
@@ -218,6 +219,7 @@ class CSVExporter:
                 "clean_fqdn_webgroups": "clean_fqdn_webgroups.csv",
                 "unsupported_fqdn_rules": "unsupported_fqdn_rules.csv",
                 "unsupported_fqdn_domains_df": "unsupported_fqdn_domains.csv",
+                "unsupported_cidr_entries_df": "unsupported_cidr_entries.csv",
             }
 
             for key, filename in debug_exports.items():

--- a/translator/src/data/loaders.py
+++ b/translator/src/data/loaders.py
@@ -277,7 +277,8 @@ class ControllerVersionLoader:
 
         if not file_path.exists():
             self.logger.warning(f"Controller version file not found: {file_path}")
-            self.logger.warning("Defaulting to version 8.0 behavior (filter incompatible domains)")
+            if not self.config.include_advanced_wildcards:
+                self.logger.warning("Defaulting to version 8.0 behavior (filter incompatible domains)")
             return "8.0.0"
 
         try:
@@ -295,7 +296,8 @@ class ControllerVersionLoader:
 
         except Exception as e:
             self.logger.error(f"Failed to load controller version from {file_path}: {e}")
-            self.logger.warning("Defaulting to version 8.0 behavior (filter incompatible domains)")
+            if not self.config.include_advanced_wildcards:
+                self.logger.warning("Defaulting to version 8.0 behavior (filter incompatible domains)")
             return "8.0.0"
 
     def is_version_8_1_or_higher(self, version: str) -> bool:

--- a/translator/src/data/loaders.py
+++ b/translator/src/data/loaders.py
@@ -207,7 +207,6 @@ class TerraformLoader:
             "firewall",
             "fqdn_tag_rule",
             "fqdn",
-            "smart_group",
         ]
 
         for resource_name in resource_names:

--- a/translator/src/data/loaders.py
+++ b/translator/src/data/loaders.py
@@ -260,6 +260,76 @@ class GatewayDetailsLoader:
             return pd.DataFrame()
 
 
+class ControllerVersionLoader:
+    """Loads controller version information from JSON configuration."""
+
+    def __init__(self, config: TranslationConfig):
+        self.config = config
+        self.logger = logging.getLogger(__name__)
+
+    def load_controller_version(self) -> str:
+        """
+        Load controller version from JSON file.
+
+        Returns:
+            Controller version string (e.g., "7.2.5090", "8.1.1234")
+        """
+        file_path = self.config.get_input_file_path("controller_version")
+
+        if not file_path.exists():
+            self.logger.warning(f"Controller version file not found: {file_path}")
+            self.logger.warning("Defaulting to version 8.0 behavior (filter incompatible domains)")
+            return "8.0.0"
+
+        try:
+            with open(file_path) as fp:
+                version_data = json.load(fp)
+
+            if "results" not in version_data:
+                self.logger.error("Invalid controller version format - missing 'results' key")
+                return "8.0.0"
+
+            current_version = version_data["results"].get("current_version", "8.0.0")
+            
+            self.logger.info(f"Loaded controller version: {current_version}")
+            return current_version
+
+        except Exception as e:
+            self.logger.error(f"Failed to load controller version from {file_path}: {e}")
+            self.logger.warning("Defaulting to version 8.0 behavior (filter incompatible domains)")
+            return "8.0.0"
+
+    def is_version_8_1_or_higher(self, version: str) -> bool:
+        """
+        Check if the controller version is 8.1 or higher.
+
+        Args:
+            version: Version string (e.g., "7.2.5090", "8.1.1234")
+
+        Returns:
+            True if version is 8.1 or higher, False otherwise
+        """
+        try:
+            # Parse version string - expects format like "8.1.1234" or "7.2.5090"
+            version_parts = version.split(".")
+            if len(version_parts) < 2:
+                self.logger.warning(f"Invalid version format: {version}, defaulting to 8.0 behavior")
+                return False
+            
+            major = int(version_parts[0])
+            minor = int(version_parts[1])
+            
+            # Version 8.1 or higher
+            if major > 8 or (major == 8 and minor >= 1):
+                return True
+            else:
+                return False
+                
+        except (ValueError, IndexError) as e:
+            self.logger.error(f"Failed to parse version {version}: {e}")
+            return False
+
+
 class ConfigurationLoader:
     """Main configuration loader that orchestrates all data loading."""
 
@@ -267,6 +337,7 @@ class ConfigurationLoader:
         self.config = config
         self.tf_loader = TerraformLoader(config)
         self.gateway_loader = GatewayDetailsLoader(config)
+        self.controller_version_loader = ControllerVersionLoader(config)
         self.copilot_loader = CoPilotAssetLoader(config.input_dir)
         self.logger = logging.getLogger(__name__)
 

--- a/translator/src/domain/constants.py
+++ b/translator/src/domain/constants.py
@@ -20,6 +20,17 @@ class UnsupportedFQDNRecord:
     protocol: str
     reason: str
 
+@dataclass
+class UnsupportedCIDRRecord:
+    """Record for tracking CIDR/IP entries found in FQDN fields during translation."""
+    fqdn_tag_name: str
+    webgroup_name: str
+    cidr_entry: str
+    port: str
+    protocol: str
+    entry_type: str  # "CIDR" or "IP"
+    reason: str
+
 # Protocol mappings and constants
 PROTOCOL_MAPPINGS = {
     "all": "ANY",

--- a/translator/src/main.py
+++ b/translator/src/main.py
@@ -349,7 +349,9 @@ def main() -> int:
 
         # Initialize unsupported FQDN tracker for comprehensive reporting
         from translation.unsupported_fqdn_tracker import UnsupportedFQDNTracker
+        from translation.unsupported_cidr_tracker import UnsupportedCIDRTracker
         unsupported_fqdn_tracker = UnsupportedFQDNTracker()
+        unsupported_cidr_tracker = UnsupportedCIDRTracker()
 
         # Initialize FQDN handler and process FQDN rules
         logging.info("Processing FQDN rules...")
@@ -359,6 +361,7 @@ def main() -> int:
             pretty_parse_vpc_name,
             deduplicate_policy_names,
             unsupported_fqdn_tracker,
+            unsupported_cidr_tracker,
             skip_incompatible_domain_filtering
         )
 
@@ -466,6 +469,7 @@ def main() -> int:
             "full_policy_list": full_policy_list,
             "unsupported_rules_df": unsupported_rules_df,
             "unsupported_fqdn_domains_df": unsupported_fqdn_tracker.to_dataframe(),
+            "unsupported_cidr_entries_df": unsupported_cidr_tracker.to_dataframe(),
         }
 
         # Initialize data exporter and export all outputs
@@ -522,6 +526,7 @@ def main() -> int:
         
         # Log unsupported FQDN summary
         unsupported_fqdn_tracker.log_summary()
+        unsupported_cidr_tracker.log_summary()
 
         return 0
 

--- a/translator/src/translation/unsupported_cidr_tracker.py
+++ b/translator/src/translation/unsupported_cidr_tracker.py
@@ -1,0 +1,208 @@
+"""
+Tracker for CIDR/IP entries found in FQDN fields during DCF translation.
+
+This module handles tracking of CIDR blocks and IP addresses that appear in FQDN 
+fields but cannot be used in SNI filters for web groups.
+"""
+
+import logging
+from collections import defaultdict
+from dataclasses import asdict
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from domain.constants import UnsupportedCIDRRecord
+
+
+class UnsupportedCIDRTracker:
+    """
+    Centralized tracker for CIDR/IP entries found in FQDN fields during DCF translation.
+    
+    This class collects and manages details about CIDR blocks and IP addresses that are
+    filtered out from web groups during the translation process, providing comprehensive
+    reporting and analysis capabilities.
+    """
+    
+    def __init__(self):
+        """Initialize the tracker with empty collections."""
+        self.records: List[UnsupportedCIDRRecord] = []
+        self._logger = logging.getLogger(__name__)
+    
+    def add_record(self, record: UnsupportedCIDRRecord) -> None:
+        """
+        Add an unsupported CIDR record to the tracker.
+        
+        Args:
+            record: The UnsupportedCIDRRecord to add
+        """
+        self.records.append(record)
+        self._logger.debug(f"Added unsupported CIDR record: {record.cidr_entry} for {record.webgroup_name}")
+    
+    def add_cidr_entry(
+        self,
+        fqdn_tag_name: str,
+        webgroup_name: str,
+        cidr_entry: str,
+        port: str,
+        protocol: str,
+        entry_type: str,
+        reason: str = "CIDR/IP notation not supported in SNI filters"
+    ) -> None:
+        """
+        Add a CIDR/IP entry record with individual parameters.
+        
+        Args:
+            fqdn_tag_name: The name of the FQDN tag
+            webgroup_name: The name of the webgroup
+            cidr_entry: The CIDR block or IP address
+            port: The port number
+            protocol: The protocol (TCP/UDP)
+            entry_type: The type of entry ("CIDR" or "IP")
+            reason: The reason for rejection
+        """
+        record = UnsupportedCIDRRecord(
+            fqdn_tag_name=fqdn_tag_name,
+            webgroup_name=webgroup_name,
+            cidr_entry=cidr_entry,
+            port=port,
+            protocol=protocol,
+            entry_type=entry_type,
+            reason=reason
+        )
+        self.add_record(record)
+    
+    def get_total_count(self) -> int:
+        """Get the total number of unsupported CIDR entries."""
+        return len(self.records)
+    
+    def get_affected_webgroups_count(self) -> int:
+        """Get the number of unique webgroups affected by unsupported CIDR entries."""
+        return len(set(record.webgroup_name for record in self.records))
+    
+    def get_affected_fqdn_tags_count(self) -> int:
+        """Get the number of unique FQDN tags affected by unsupported CIDR entries."""
+        return len(set(record.fqdn_tag_name for record in self.records))
+    
+    def get_summary_by_type(self) -> Dict[str, int]:
+        """
+        Get a summary of unsupported entries grouped by type (CIDR vs IP).
+        
+        Returns:
+            Dictionary mapping entry types to counts
+        """
+        type_counts = defaultdict(int)
+        for record in self.records:
+            type_counts[record.entry_type] += 1
+        return dict(type_counts)
+    
+    def get_summary_by_webgroup(self) -> Dict[str, int]:
+        """
+        Get a summary of unsupported CIDR entries grouped by webgroup.
+        
+        Returns:
+            Dictionary mapping webgroup names to counts
+        """
+        webgroup_counts = defaultdict(int)
+        for record in self.records:
+            webgroup_counts[record.webgroup_name] += 1
+        return dict(webgroup_counts)
+    
+    def get_summary_by_fqdn_tag(self) -> Dict[str, int]:
+        """
+        Get a summary of unsupported CIDR entries grouped by FQDN tag.
+        
+        Returns:
+            Dictionary mapping FQDN tag names to counts
+        """
+        tag_counts = defaultdict(int)
+        for record in self.records:
+            tag_counts[record.fqdn_tag_name] += 1
+        return dict(tag_counts)
+    
+    def get_top_cidr_entries(self, limit: int = 10) -> List[Dict[str, int]]:
+        """
+        Get the most frequently occurring CIDR entries.
+        
+        Args:
+            limit: Maximum number of entries to return
+            
+        Returns:
+            List of dictionaries with cidr_entry and count
+        """
+        cidr_counts = defaultdict(int)
+        for record in self.records:
+            cidr_counts[record.cidr_entry] += 1
+        
+        sorted_cidrs = sorted(cidr_counts.items(), key=lambda x: x[1], reverse=True)
+        return [{"cidr_entry": cidr, "count": count} for cidr, count in sorted_cidrs[:limit]]
+    
+    def get_comprehensive_summary(self) -> Dict[str, any]:
+        """
+        Get a comprehensive summary of all unsupported CIDR statistics.
+        
+        Returns:
+            Dictionary with detailed statistics
+        """
+        return {
+            "total_count": self.get_total_count(),
+            "affected_webgroups": self.get_affected_webgroups_count(),
+            "affected_fqdn_tags": self.get_affected_fqdn_tags_count(),
+            "by_type": self.get_summary_by_type(),
+            "by_webgroup": self.get_summary_by_webgroup(),
+            "by_fqdn_tag": self.get_summary_by_fqdn_tag(),
+            "top_cidr_entries": self.get_top_cidr_entries(10)
+        }
+    
+    def to_dataframe(self) -> pd.DataFrame:
+        """
+        Convert all records to a pandas DataFrame for CSV export.
+        
+        Returns:
+            DataFrame with all unsupported CIDR records
+        """
+        if not self.records:
+            # Return empty DataFrame with proper columns
+            return pd.DataFrame(columns=[
+                "fqdn_tag_name", "webgroup_name", "cidr_entry", "port", "protocol", "entry_type", "reason"
+            ])
+        
+        return pd.DataFrame([asdict(record) for record in self.records])
+    
+    def log_summary(self, log_level: int = logging.INFO) -> None:
+        """
+        Log a comprehensive summary of unsupported CIDR entries.
+        
+        Args:
+            log_level: The logging level to use
+        """
+        if not self.records:
+            self._logger.log(log_level, "No unsupported CIDR entries found during translation")
+            return
+        
+        summary = self.get_comprehensive_summary()
+        
+        self._logger.log(log_level, f"=== Unsupported CIDR Entries Summary ===")
+        self._logger.log(log_level, f"Total unsupported CIDR entries: {summary['total_count']}")
+        self._logger.log(log_level, f"Affected webgroups: {summary['affected_webgroups']}")
+        self._logger.log(log_level, f"Affected FQDN tags: {summary['affected_fqdn_tags']}")
+        
+        self._logger.log(log_level, "Breakdown by type:")
+        for entry_type, count in summary['by_type'].items():
+            self._logger.log(log_level, f"  {entry_type}: {count} entries")
+        
+        self._logger.log(log_level, "Top 5 most affected webgroups:")
+        sorted_webgroups = sorted(summary['by_webgroup'].items(), key=lambda x: x[1], reverse=True)
+        for webgroup, count in sorted_webgroups[:5]:
+            self._logger.log(log_level, f"  {webgroup}: {count} entries")
+        
+        self._logger.log(log_level, "Top 5 most common CIDR entries:")
+        for entry_info in summary['top_cidr_entries'][:5]:
+            self._logger.log(log_level, f"  {entry_info['cidr_entry']}: {entry_info['count']} occurrences")
+        
+        self._logger.log(log_level, "=== End Unsupported CIDR Summary ===")
+    
+    def clear(self) -> None:
+        """Clear all records from the tracker."""
+        self.records.clear()
+        self._logger.debug("Cleared all unsupported CIDR records")

--- a/translator/src/translation/webgroups.py
+++ b/translator/src/translation/webgroups.py
@@ -169,8 +169,8 @@ class WebGroupBuilder:
 class WebGroupManager:
     """High-level manager for WebGroup operations."""
 
-    def __init__(self, unsupported_fqdn_tracker: Optional[UnsupportedFQDNTracker] = None) -> None:
-        self.builder = WebGroupBuilder(unsupported_fqdn_tracker)
+    def __init__(self, unsupported_fqdn_tracker: Optional[UnsupportedFQDNTracker] = None, skip_incompatible_domain_filtering: bool = False) -> None:
+        self.builder = WebGroupBuilder(unsupported_fqdn_tracker, skip_incompatible_domain_filtering)
         self.unsupported_fqdn_tracker = self.builder.unsupported_fqdn_tracker
 
     def create_webgroups_from_fqdn_rules(self, fqdn_tag_rule_df: pd.DataFrame) -> pd.DataFrame:

--- a/translator/src/translation/webgroups.py
+++ b/translator/src/translation/webgroups.py
@@ -12,22 +12,26 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from ..config import TranslationConfig
-from ..config.defaults import DCF_CONSTRAINTS
-from ..data.processors import DataCleaner
-from ..domain.constants import FQDN_MODE_MAPPINGS
-from ..utils.data_processing import normalize_protocol
+from config import TranslationConfig
+from config.defaults import DCF_CONSTRAINTS
+from data.processors import DataCleaner
+from domain.constants import FQDN_MODE_MAPPINGS
+from utils.data_processing import normalize_protocol
+from utils.cidr_validator import CIDRValidator
 from .fqdn_handlers import FQDNValidator
 from .unsupported_fqdn_tracker import UnsupportedFQDNTracker
+from .unsupported_cidr_tracker import UnsupportedCIDRTracker
 
 
 class WebGroupBuilder:
     """Handles the creation and management of WebGroups from FQDN tag rules."""
 
-    def __init__(self, unsupported_fqdn_tracker: Optional[UnsupportedFQDNTracker] = None) -> None:
+    def __init__(self, unsupported_fqdn_tracker: Optional[UnsupportedFQDNTracker] = None, unsupported_cidr_tracker: Optional[UnsupportedCIDRTracker] = None, skip_incompatible_domain_filtering: bool = False) -> None:
         self.all_invalid_domains: List[Dict[str, str]] = []
         self.cleaner = DataCleaner(TranslationConfig())
         self.unsupported_fqdn_tracker = unsupported_fqdn_tracker or UnsupportedFQDNTracker()
+        self.unsupported_cidr_tracker = unsupported_cidr_tracker or UnsupportedCIDRTracker()
+        self.skip_incompatible_domain_filtering = skip_incompatible_domain_filtering
 
     def create_webgroup_name(self, row: pd.Series) -> str:
         """
@@ -58,13 +62,36 @@ class WebGroupBuilder:
         port = str(row["port"])
         original_domains = row["fqdn"]
         
+        # First filter out CIDR and IP address entries
+        # Filter out CIDR entries that aren't valid for SNI filters (IP addresses are valid)
+        domains_without_cidr, cidr_entries = CIDRValidator.filter_cidr_notation(
+            original_domains, f"WebGroup {webgroup_name}"
+        )
+        
+        # Track CIDR entries that were filtered out
+        if cidr_entries:
+            logging.warning(f"WebGroup '{webgroup_name}' had {len(cidr_entries)} CIDR entries filtered: {cidr_entries}")
+            for cidr_entry in cidr_entries:
+                self.unsupported_cidr_tracker.add_cidr_entry(
+                    fqdn_tag_name=fqdn_tag_name,
+                    webgroup_name=webgroup_name,
+                    cidr_entry=cidr_entry,
+                    port=port,
+                    protocol=protocol,
+                    entry_type="CIDR",
+                    reason="CIDR notation not supported in SNI filters"
+                )
+        
+        # Then filter remaining domains for DCF 8.0 compatibility
         valid_domains, invalid_domains = FQDNValidator.filter_domains_for_dcf_compatibility(
-            original_domains, webgroup_name
+            domains_without_cidr, webgroup_name, self.skip_incompatible_domain_filtering
         )
 
         # Log if all domains were filtered out
         if len(original_domains) > 0 and len(valid_domains) == 0:
-            logging.warning(f"WebGroup '{webgroup_name}' will be empty - all {len(original_domains)} domains were DCF-incompatible")
+            cidr_count = len(cidr_entries)
+            invalid_count = len(invalid_domains)
+            logging.warning(f"WebGroup '{webgroup_name}' will be empty - all {len(original_domains)} entries were filtered ({cidr_count} CIDR, {invalid_count} DCF-incompatible)")
 
         if invalid_domains:
             # Store invalid domains for reporting (legacy format)
@@ -169,9 +196,10 @@ class WebGroupBuilder:
 class WebGroupManager:
     """High-level manager for WebGroup operations."""
 
-    def __init__(self, unsupported_fqdn_tracker: Optional[UnsupportedFQDNTracker] = None, skip_incompatible_domain_filtering: bool = False) -> None:
-        self.builder = WebGroupBuilder(unsupported_fqdn_tracker, skip_incompatible_domain_filtering)
+    def __init__(self, unsupported_fqdn_tracker: Optional[UnsupportedFQDNTracker] = None, unsupported_cidr_tracker: Optional[UnsupportedCIDRTracker] = None, skip_incompatible_domain_filtering: bool = False) -> None:
+        self.builder = WebGroupBuilder(unsupported_fqdn_tracker, unsupported_cidr_tracker, skip_incompatible_domain_filtering)
         self.unsupported_fqdn_tracker = self.builder.unsupported_fqdn_tracker
+        self.unsupported_cidr_tracker = self.builder.unsupported_cidr_tracker
 
     def create_webgroups_from_fqdn_rules(self, fqdn_tag_rule_df: pd.DataFrame) -> pd.DataFrame:
         """

--- a/translator/src/utils/cidr_validator.py
+++ b/translator/src/utils/cidr_validator.py
@@ -1,0 +1,98 @@
+"""
+CIDR notation validation utilities for the legacy-to-DCF policy translator.
+
+This module provides functionality to detect and handle CIDR notation in FQDN fields,
+which are invalid for SNI filters in web groups.
+"""
+
+import ipaddress
+import re
+from typing import List, Tuple
+
+
+class CIDRValidator:
+    """Validates and filters CIDR notation from domain lists."""
+
+    # Pattern to match IPv4 CIDR notation (e.g., 192.168.1.1/24, 10.0.0.0/8)
+    CIDR_PATTERN = re.compile(r'^(\d{1,3}\.){3}\d{1,3}/\d{1,2}$')
+
+    @staticmethod
+    def is_cidr_notation(value: str) -> bool:
+        """
+        Check if a string represents CIDR notation.
+
+        Args:
+            value: String to check
+
+        Returns:
+            True if the value is CIDR notation, False otherwise
+        """
+        if not value or not isinstance(value, str):
+            return False
+
+        value = value.strip()
+        
+        # First check with regex for performance
+        if not CIDRValidator.CIDR_PATTERN.match(value):
+            return False
+
+        # Validate it's actually a valid CIDR block
+        try:
+            ipaddress.IPv4Network(value, strict=False)
+            return True
+        except (ipaddress.AddressValueError, ValueError):
+            return False
+
+    @staticmethod
+    def is_ip_address(value: str) -> bool:
+        """
+        Check if a string represents an IP address (without CIDR notation).
+
+        Args:
+            value: String to check
+
+        Returns:
+            True if the value is an IP address, False otherwise
+        """
+        if not value or not isinstance(value, str):
+            return False
+
+        value = value.strip()
+        
+        # Check if it looks like an IP address (no slash)
+        if '/' in value:
+            return False
+
+        try:
+            ipaddress.IPv4Address(value)
+            return True
+        except (ipaddress.AddressValueError, ValueError):
+            return False
+
+    @staticmethod
+    def filter_cidr_notation(
+        fqdn_list: List[str], 
+        context_name: str = None
+    ) -> Tuple[List[str], List[str]]:
+        """
+        Filter CIDR notation from FQDN list. IP addresses are valid in SNI filters.
+
+        Args:
+            fqdn_list: List of domain strings that may contain CIDR entries
+            context_name: Name for logging context (optional)
+
+        Returns:
+            Tuple of (valid_domains, invalid_entries)
+            - valid_domains: List of actual domain names and IP addresses
+            - invalid_entries: List of CIDR blocks that were filtered out
+        """
+        valid_domains = []
+        invalid_entries = []
+
+        for entry in fqdn_list:
+            if CIDRValidator.is_cidr_notation(entry):
+                invalid_entries.append(entry)
+            else:
+                valid_domains.append(entry)
+
+        return valid_domains, invalid_entries


### PR DESCRIPTION
- The export bundle now collects the Controller version
- The translator will include/exclude advanced wildcards based on detected Controller version
- If the version .json isn't detected for some reason, advanced wildcards will be excluded
- Added an optional flag --include advanced-wildcards to include the advanced wildcards regardless of version
- Removed smart_group.tf warning in the translator since the exporter never tries to collect smart group information